### PR TITLE
Make entities filterable by associated entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require verification of registered databases [#160](https://github.com/building-envelope-data/metabase/pull/160)
 - Forward GraphQL errors returned when querying databases for data [bf6d16099cb3f9681883d9a6f20eada4185044c7](https://github.com/building-envelope-data/metabase/commit/bf6d16099cb3f9681883d9a6f20eada4185044c7)
 - Enable automatic persisted queries [94277dfc336af87f279a549b38567dd9c13de233](https://github.com/building-envelope-data/metabase/commit/94277dfc336af87f279a549b38567dd9c13de233)
--
+- Make entities filterable by associated entities [#167](https://github.com/building-envelope-data/metabase/pull/167)
 -
 -
 -

--- a/backend/src/Configuration/GraphQlConfiguration.cs
+++ b/backend/src/Configuration/GraphQlConfiguration.cs
@@ -155,11 +155,16 @@ namespace Metabase.Configuration
                    new FilterConventionExtension(descriptor =>
                      {
                          descriptor.BindRuntimeType<Data.Component, GraphQl.Components.ComponentFilterType>();
+                         descriptor.BindRuntimeType<Data.ComponentAssembly, GraphQl.ComponentAssemblies.ComponentAssemblyFilterType>();
+                         descriptor.BindRuntimeType<Data.ComponentManufacturer, GraphQl.ComponentManufacturers.ComponentManufacturerFilterType>();
                          descriptor.BindRuntimeType<Data.DataFormat, GraphQl.DataFormats.DataFormatFilterType>();
                          descriptor.BindRuntimeType<Data.Database, GraphQl.Databases.DatabaseFilterType>();
                          descriptor.BindRuntimeType<Data.Institution, GraphQl.Institutions.InstitutionFilterType>();
+                         descriptor.BindRuntimeType<Data.InstitutionMethodDeveloper, GraphQl.InstitutionMethodDevelopers.InstitutionMethodDeveloperFilterType>();
+                         descriptor.BindRuntimeType<Data.InstitutionRepresentative, GraphQl.InstitutionRepresentatives.InstitutionRepresentativeFilterType>();
                          descriptor.BindRuntimeType<Data.Method, GraphQl.Methods.MethodFilterType>();
                          descriptor.BindRuntimeType<Data.User, GraphQl.Users.UserFilterType>();
+                         descriptor.BindRuntimeType<Data.UserMethodDeveloper, GraphQl.UserMethodDevelopers.UserMethodDeveloperFilterType>();
                      }
                      )
                    )

--- a/backend/src/Configuration/GraphQlConfiguration.cs
+++ b/backend/src/Configuration/GraphQlConfiguration.cs
@@ -159,6 +159,7 @@ namespace Metabase.Configuration
                          descriptor.BindRuntimeType<Data.Database, GraphQl.Databases.DatabaseFilterType>();
                          descriptor.BindRuntimeType<Data.Institution, GraphQl.Institutions.InstitutionFilterType>();
                          descriptor.BindRuntimeType<Data.Method, GraphQl.Methods.MethodFilterType>();
+                         descriptor.BindRuntimeType<Data.User, GraphQl.Users.UserFilterType>();
                      }
                      )
                    )

--- a/backend/src/GraphQl/ComponentAssemblies/ComponentAssemblyFilterType.cs
+++ b/backend/src/GraphQl/ComponentAssemblies/ComponentAssemblyFilterType.cs
@@ -1,0 +1,19 @@
+using HotChocolate.Data.Filters;
+
+namespace Metabase.GraphQl.ComponentAssemblies
+{
+    public sealed class ComponentAssemblyFilterType
+      : FilterInputType<Data.ComponentAssembly>
+    {
+        protected override void Configure(
+          IFilterInputTypeDescriptor<Data.ComponentAssembly> descriptor
+          )
+        {
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.AssembledComponent);
+            descriptor.Field(x => x.PartComponent);
+            descriptor.Field(x => x.Index);
+            descriptor.Field(x => x.PrimeSurface);
+        }
+    }
+}

--- a/backend/src/GraphQl/ComponentManufacturers/ComponentManufacturerFilterType.cs
+++ b/backend/src/GraphQl/ComponentManufacturers/ComponentManufacturerFilterType.cs
@@ -1,0 +1,18 @@
+using HotChocolate.Data.Filters;
+
+namespace Metabase.GraphQl.ComponentManufacturers
+{
+    public sealed class ComponentManufacturerFilterType
+      : FilterInputType<Data.ComponentManufacturer>
+    {
+        protected override void Configure(
+          IFilterInputTypeDescriptor<Data.ComponentManufacturer> descriptor
+          )
+        {
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.Component);
+            descriptor.Field(x => x.Institution);
+            descriptor.Field(x => x.Pending);
+        }
+    }
+}

--- a/backend/src/GraphQl/Components/ComponentFilterType.cs
+++ b/backend/src/GraphQl/Components/ComponentFilterType.cs
@@ -15,6 +15,12 @@ namespace Metabase.GraphQl.Components
             descriptor.Field(x => x.Abbreviation);
             descriptor.Field(x => x.Description);
             descriptor.Field(x => x.Categories);
+            descriptor.Field(x => x.PartOf);
+            descriptor.Field(x => x.Parts);
+            descriptor.Field(x => x.Concretizations);
+            descriptor.Field(x => x.Generalizations);
+            descriptor.Field(x => x.Variants);
+            descriptor.Field(x => x.Manufacturers);
             // TODO Allow filtering by Availability. How? See https://chillicream.com/docs/hotchocolate/fetching-data/filtering/#customization
         }
     }

--- a/backend/src/GraphQl/Components/ComponentFilterType.cs
+++ b/backend/src/GraphQl/Components/ComponentFilterType.cs
@@ -17,10 +17,13 @@ namespace Metabase.GraphQl.Components
             descriptor.Field(x => x.Categories);
             descriptor.Field(x => x.PartOf);
             descriptor.Field(x => x.Parts);
+            descriptor.Field(x => x.PartOfEdges);
+            descriptor.Field(x => x.PartEdges);
             descriptor.Field(x => x.Concretizations);
             descriptor.Field(x => x.Generalizations);
             descriptor.Field(x => x.Variants);
             descriptor.Field(x => x.Manufacturers);
+            descriptor.Field(x => x.ManufacturerEdges);
             // TODO Allow filtering by Availability. How? See https://chillicream.com/docs/hotchocolate/fetching-data/filtering/#customization
         }
     }

--- a/backend/src/GraphQl/DataFormat/DataFormatFilterType.cs
+++ b/backend/src/GraphQl/DataFormat/DataFormatFilterType.cs
@@ -12,8 +12,11 @@ namespace Metabase.GraphQl.DataFormats
             descriptor.BindFieldsExplicitly();
             descriptor.Field(x => x.Id);
             descriptor.Field(x => x.Name);
+            descriptor.Field(x => x.Extension);
             descriptor.Field(x => x.Description);
             descriptor.Field(x => x.MediaType);
+            descriptor.Field(x => x.SchemaLocator);
+            descriptor.Field(x => x.Manager);
         }
     }
 }

--- a/backend/src/GraphQl/DataFormat/DataFormatFilterType.cs
+++ b/backend/src/GraphQl/DataFormat/DataFormatFilterType.cs
@@ -16,6 +16,8 @@ namespace Metabase.GraphQl.DataFormats
             descriptor.Field(x => x.Description);
             descriptor.Field(x => x.MediaType);
             descriptor.Field(x => x.SchemaLocator);
+            descriptor.Field(x => x.Standard);
+            descriptor.Field(x => x.Publication);
             descriptor.Field(x => x.Manager);
         }
     }

--- a/backend/src/GraphQl/Databases/DatabaseFilterType.cs
+++ b/backend/src/GraphQl/Databases/DatabaseFilterType.cs
@@ -14,6 +14,7 @@ namespace Metabase.GraphQl.Databases
             descriptor.Field(x => x.Name);
             descriptor.Field(x => x.Description);
             descriptor.Field(x => x.Locator);
+            descriptor.Field(x => x.Operator);
         }
     }
 }

--- a/backend/src/GraphQl/InstitutionMethodDevelopers/InstitutionMethodDeveloperFilterType.cs
+++ b/backend/src/GraphQl/InstitutionMethodDevelopers/InstitutionMethodDeveloperFilterType.cs
@@ -1,0 +1,18 @@
+using HotChocolate.Data.Filters;
+
+namespace Metabase.GraphQl.InstitutionMethodDevelopers
+{
+    public sealed class InstitutionMethodDeveloperFilterType
+      : FilterInputType<Data.InstitutionMethodDeveloper>
+    {
+        protected override void Configure(
+          IFilterInputTypeDescriptor<Data.InstitutionMethodDeveloper> descriptor
+          )
+        {
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.Method);
+            descriptor.Field(x => x.Institution);
+            descriptor.Field(x => x.Pending);
+        }
+    }
+}

--- a/backend/src/GraphQl/InstitutionRepresentatives/InstitutionRepresentativeFilterType.cs
+++ b/backend/src/GraphQl/InstitutionRepresentatives/InstitutionRepresentativeFilterType.cs
@@ -1,0 +1,19 @@
+using HotChocolate.Data.Filters;
+
+namespace Metabase.GraphQl.InstitutionRepresentatives
+{
+    public sealed class InstitutionRepresentativeFilterType
+      : FilterInputType<Data.InstitutionRepresentative>
+    {
+        protected override void Configure(
+          IFilterInputTypeDescriptor<Data.InstitutionRepresentative> descriptor
+          )
+        {
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.Institution);
+            descriptor.Field(x => x.User);
+            descriptor.Field(x => x.Role);
+            descriptor.Field(x => x.Pending);
+        }
+    }
+}

--- a/backend/src/GraphQl/Institutions/InstitutionFilterType.cs
+++ b/backend/src/GraphQl/Institutions/InstitutionFilterType.cs
@@ -17,13 +17,16 @@ namespace Metabase.GraphQl.Institutions
             descriptor.Field(x => x.WebsiteLocator);
             descriptor.Field(x => x.State);
             descriptor.Field(x => x.DevelopedMethods);
+            descriptor.Field(x => x.DevelopedMethodEdges);
             descriptor.Field(x => x.ManagedMethods);
             descriptor.Field(x => x.ManagedDataFormats);
             descriptor.Field(x => x.ManufacturedComponents);
+            descriptor.Field(x => x.ManufacturedComponentEdges);
             descriptor.Field(x => x.OperatedDatabases);
             descriptor.Field(x => x.Manager);
             descriptor.Field(x => x.ManagedInstitutions);
             descriptor.Field(x => x.Representatives);
+            descriptor.Field(x => x.RepresentativeEdges);
         }
     }
 }

--- a/backend/src/GraphQl/Institutions/InstitutionFilterType.cs
+++ b/backend/src/GraphQl/Institutions/InstitutionFilterType.cs
@@ -16,6 +16,14 @@ namespace Metabase.GraphQl.Institutions
             descriptor.Field(x => x.Description);
             descriptor.Field(x => x.WebsiteLocator);
             descriptor.Field(x => x.State);
+            descriptor.Field(x => x.DevelopedMethods);
+            descriptor.Field(x => x.ManagedMethods);
+            descriptor.Field(x => x.ManagedDataFormats);
+            descriptor.Field(x => x.ManufacturedComponents);
+            descriptor.Field(x => x.OperatedDatabases);
+            descriptor.Field(x => x.Manager);
+            descriptor.Field(x => x.ManagedInstitutions);
+            descriptor.Field(x => x.Representatives);
         }
     }
 }

--- a/backend/src/GraphQl/Methods/MethodFilterType.cs
+++ b/backend/src/GraphQl/Methods/MethodFilterType.cs
@@ -13,6 +13,8 @@ namespace Metabase.GraphQl.Methods
             descriptor.Field(x => x.Id);
             descriptor.Field(x => x.Name);
             descriptor.Field(x => x.Description);
+            descriptor.Field(x => x.Standard);
+            descriptor.Field(x => x.Publication);
             descriptor.Field(x => x.CalculationLocator);
             descriptor.Field(x => x.Categories);
             descriptor.Field(x => x.InstitutionDevelopers);

--- a/backend/src/GraphQl/Methods/MethodFilterType.cs
+++ b/backend/src/GraphQl/Methods/MethodFilterType.cs
@@ -13,7 +13,11 @@ namespace Metabase.GraphQl.Methods
             descriptor.Field(x => x.Id);
             descriptor.Field(x => x.Name);
             descriptor.Field(x => x.Description);
+            descriptor.Field(x => x.CalculationLocator);
             descriptor.Field(x => x.Categories);
+            descriptor.Field(x => x.InstitutionDevelopers);
+            descriptor.Field(x => x.UserDevelopers);
+            descriptor.Field(x => x.Manager);
         }
     }
 }

--- a/backend/src/GraphQl/Methods/MethodFilterType.cs
+++ b/backend/src/GraphQl/Methods/MethodFilterType.cs
@@ -18,7 +18,9 @@ namespace Metabase.GraphQl.Methods
             descriptor.Field(x => x.CalculationLocator);
             descriptor.Field(x => x.Categories);
             descriptor.Field(x => x.InstitutionDevelopers);
+            descriptor.Field(x => x.InstitutionDeveloperEdges);
             descriptor.Field(x => x.UserDevelopers);
+            descriptor.Field(x => x.UserDeveloperEdges);
             descriptor.Field(x => x.Manager);
         }
     }

--- a/backend/src/GraphQl/UserMethodDevelopers/UserMethodDeveloperFilterType.cs
+++ b/backend/src/GraphQl/UserMethodDevelopers/UserMethodDeveloperFilterType.cs
@@ -1,0 +1,18 @@
+using HotChocolate.Data.Filters;
+
+namespace Metabase.GraphQl.UserMethodDevelopers
+{
+    public sealed class UserMethodDeveloperFilterType
+      : FilterInputType<Data.UserMethodDeveloper>
+    {
+        protected override void Configure(
+          IFilterInputTypeDescriptor<Data.UserMethodDeveloper> descriptor
+          )
+        {
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.Method);
+            descriptor.Field(x => x.User);
+            descriptor.Field(x => x.Pending);
+        }
+    }
+}

--- a/backend/src/GraphQl/Users/UserFilterType.cs
+++ b/backend/src/GraphQl/Users/UserFilterType.cs
@@ -17,7 +17,9 @@ namespace Metabase.GraphQl.Users
             // descriptor.Field(x => x.PostalAddress);
             // descriptor.Field(x => x.WebsiteLocator);
             descriptor.Field(x => x.DevelopedMethods);
+            descriptor.Field(x => x.DevelopedMethodEdges);
             descriptor.Field(x => x.RepresentedInstitutions);
+            descriptor.Field(x => x.RepresentedInstitutionEdges);
         }
     }
 }

--- a/backend/src/GraphQl/Users/UserFilterType.cs
+++ b/backend/src/GraphQl/Users/UserFilterType.cs
@@ -1,0 +1,23 @@
+using HotChocolate.Data.Filters;
+
+namespace Metabase.GraphQl.Users
+{
+    public sealed class UserFilterType
+      : FilterInputType<Data.User>
+    {
+        protected override void Configure(
+          IFilterInputTypeDescriptor<Data.User> descriptor
+          )
+        {
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.Id);
+            // TODO The commented fiels below should be filterable by OpenId Connect Clients and application users with the proper scopes and rights. If they are filterable in general, it is a way to figure out that information even if it is not returned by GraphQL.
+            // descriptor.Field(x => x.Name);
+            // descriptor.Field(x => x.Email);
+            // descriptor.Field(x => x.PostalAddress);
+            // descriptor.Field(x => x.WebsiteLocator);
+            descriptor.Field(x => x.DevelopedMethods);
+            descriptor.Field(x => x.RepresentedInstitutions);
+        }
+    }
+}

--- a/backend/test/Integration/GraphQl/__snapshots__/GraphQlSchemaTests.IsUnchanged.snap
+++ b/backend/test/Integration/GraphQl/__snapshots__/GraphQlSchemaTests.IsUnchanged.snap
@@ -1851,6 +1851,8 @@ input DataFormatFilterInput {
   description: StringOperationFilterInput
   mediaType: StringOperationFilterInput
   schemaLocator: UrlOperationFilterInput
+  standard: StandardFilterInput
+  publication: PublicationFilterInput
   manager: InstitutionFilterInput
 }
 
@@ -2011,6 +2013,21 @@ input InstitutionStateOperationFilterInput {
   nin: [InstitutionState!]
 }
 
+input IntOperationFilterInput {
+  eq: Int
+  neq: Int
+  in: [Int]
+  nin: [Int]
+  gt: Int
+  ngt: Int
+  gte: Int
+  ngte: Int
+  lt: Int
+  nlt: Int
+  lte: Int
+  nlte: Int
+}
+
 input ListComponentCategoryOperationFilterInput {
   all: ComponentCategoryOperationFilterInput
   none: ComponentCategoryOperationFilterInput
@@ -2060,6 +2077,20 @@ input ListMethodFilterTypeFilterInput {
   any: Boolean
 }
 
+input ListStandardizerOperationFilterInput {
+  all: StandardizerOperationFilterInput
+  none: StandardizerOperationFilterInput
+  some: StandardizerOperationFilterInput
+  any: Boolean
+}
+
+input ListStringOperationFilterInput {
+  all: StringOperationFilterInput
+  none: StringOperationFilterInput
+  some: StringOperationFilterInput
+  any: Boolean
+}
+
 input ListUserFilterTypeFilterInput {
   all: UserFilterInput
   none: UserFilterInput
@@ -2094,6 +2125,8 @@ input MethodFilterInput {
   id: UuidOperationFilterInput
   name: StringOperationFilterInput
   description: StringOperationFilterInput
+  standard: StandardFilterInput
+  publication: PublicationFilterInput
   calculationLocator: UrlOperationFilterInput
   categories: ListMethodCategoryOperationFilterInput
   institutionDevelopers: ListInstitutionFilterTypeFilterInput
@@ -2114,6 +2147,14 @@ input MethodSortInput {
   manager: InstitutionSortInput
   id: SortEnumType
   version: SortEnumType
+}
+
+input NumerationFilterInput {
+  and: [NumerationFilterInput!]
+  or: [NumerationFilterInput!]
+  prefix: StringOperationFilterInput
+  mainNumber: StringOperationFilterInput
+  suffix: StringOperationFilterInput
 }
 
 input NumerationSortInput {
@@ -2148,6 +2189,24 @@ input PhotovoltaicDataPropositionInput {
   not: PhotovoltaicDataPropositionInput
   or: [PhotovoltaicDataPropositionInput!]
   resources: GetHttpsResourcesPropositionInput
+}
+
+input PublicationFilterInput {
+  and: [PublicationFilterInput!]
+  or: [PublicationFilterInput!]
+  title: StringOperationFilterInput
+  abstract: StringOperationFilterInput
+  "Referenced section"
+  section: StringOperationFilterInput
+  authors: ListStringOperationFilterInput
+  "The Digital Object Identifier (DOI) is a very important persistent identifier for publications. It MUST be defined here if it is available for a publication."
+  doi: StringOperationFilterInput
+  "The website arXiv.org is a free and open-access archive for publications. The arXiv identifier can be used to define a publication."
+  arXiv: StringOperationFilterInput
+  "A Uniform Resource Name (URN) can be used to define a publication. TODO: Improve the regex pattern to further restrict the string."
+  urn: StringOperationFilterInput
+  "If a persistent identifiert like DOI is defined above, this webAdress can define a convenient web address to access the publication. However, if no persistent identifier exist, this web address is the only identifier of this publication. In this case, it is important to choose a web address with a high probability to persist long."
+  webAddress: UrlOperationFilterInput
 }
 
 input PublicationSortInput {
@@ -2239,6 +2298,21 @@ input SetUserPhoneNumberInput {
 }
 
 "`ISO 52022` is an example of the abbreviation of a standardizer and the main number of the identifier."
+input StandardFilterInput {
+  and: [StandardFilterInput!]
+  or: [StandardFilterInput!]
+  title: StringOperationFilterInput
+  abstract: StringOperationFilterInput
+  "The section of the standard to which the reference refers to."
+  section: StringOperationFilterInput
+  "It is important to define the year in which the standard was issued because there can be relevant updates of one standard."
+  year: IntOperationFilterInput
+  numeration: NumerationFilterInput
+  standardizers: ListStandardizerOperationFilterInput
+  locator: UrlOperationFilterInput
+}
+
+"`ISO 52022` is an example of the abbreviation of a standardizer and the main number of the identifier."
 input StandardSortInput {
   title: SortEnumType
   abstract: SortEnumType
@@ -2248,6 +2322,13 @@ input StandardSortInput {
   year: SortEnumType
   numeration: NumerationSortInput
   locator: UriSortInput
+}
+
+input StandardizerOperationFilterInput {
+  eq: Standardizer
+  neq: Standardizer
+  in: [Standardizer!]
+  nin: [Standardizer!]
 }
 
 input StringOperationFilterInput {

--- a/backend/test/Integration/GraphQl/__snapshots__/GraphQlSchemaTests.IsUnchanged.snap
+++ b/backend/test/Integration/GraphQl/__snapshots__/GraphQlSchemaTests.IsUnchanged.snap
@@ -1658,6 +1658,26 @@ input AddUserRoleInput {
   userId: Uuid!
 }
 
+input BooleanOperationFilterInput {
+  eq: Boolean
+  neq: Boolean
+}
+
+input ByteOperationFilterInput {
+  eq: Byte
+  neq: Byte
+  in: [Byte]
+  nin: [Byte]
+  gt: Byte
+  ngt: Byte
+  gte: Byte
+  ngte: Byte
+  lt: Byte
+  nlt: Byte
+  lte: Byte
+  nlte: Byte
+}
+
 input CalorimetricDataPropositionInput {
   and: [CalorimetricDataPropositionInput!]
   componentId: UuidPropositionInput
@@ -1701,6 +1721,15 @@ input ClosedIntervalInput {
   upperBound: Float!
 }
 
+input ComponentAssemblyFilterInput {
+  and: [ComponentAssemblyFilterInput!]
+  or: [ComponentAssemblyFilterInput!]
+  assembledComponent: ComponentFilterInput
+  partComponent: ComponentFilterInput
+  index: ByteOperationFilterInput
+  primeSurface: NullableOfPrimeSurfaceOperationFilterInput
+}
+
 input ComponentCategoryOperationFilterInput {
   eq: ComponentCategory
   neq: ComponentCategory
@@ -1718,10 +1747,21 @@ input ComponentFilterInput {
   categories: ListComponentCategoryOperationFilterInput
   partOf: ListComponentFilterTypeFilterInput
   parts: ListComponentFilterTypeFilterInput
+  partOfEdges: ListComponentAssemblyFilterTypeFilterInput
+  partEdges: ListComponentAssemblyFilterTypeFilterInput
   concretizations: ListComponentFilterTypeFilterInput
   generalizations: ListComponentFilterTypeFilterInput
   variants: ListComponentFilterTypeFilterInput
   manufacturers: ListInstitutionFilterTypeFilterInput
+  manufacturerEdges: ListComponentManufacturerFilterTypeFilterInput
+}
+
+input ComponentManufacturerFilterInput {
+  and: [ComponentManufacturerFilterInput!]
+  or: [ComponentManufacturerFilterInput!]
+  component: ComponentFilterInput
+  institution: InstitutionFilterInput
+  pending: BooleanOperationFilterInput
 }
 
 input ComponentSortInput {
@@ -1984,13 +2024,40 @@ input InstitutionFilterInput {
   websiteLocator: UrlOperationFilterInput
   state: InstitutionStateOperationFilterInput
   developedMethods: ListMethodFilterTypeFilterInput
+  developedMethodEdges: ListInstitutionMethodDeveloperFilterTypeFilterInput
   managedMethods: ListMethodFilterTypeFilterInput
   managedDataFormats: ListDataFormatFilterTypeFilterInput
   manufacturedComponents: ListComponentFilterTypeFilterInput
+  manufacturedComponentEdges: ListComponentManufacturerFilterTypeFilterInput
   operatedDatabases: ListDatabaseFilterTypeFilterInput
   manager: InstitutionFilterInput
   managedInstitutions: ListInstitutionFilterTypeFilterInput
   representatives: ListUserFilterTypeFilterInput
+  representativeEdges: ListInstitutionRepresentativeFilterTypeFilterInput
+}
+
+input InstitutionMethodDeveloperFilterInput {
+  and: [InstitutionMethodDeveloperFilterInput!]
+  or: [InstitutionMethodDeveloperFilterInput!]
+  method: MethodFilterInput
+  institution: InstitutionFilterInput
+  pending: BooleanOperationFilterInput
+}
+
+input InstitutionRepresentativeFilterInput {
+  and: [InstitutionRepresentativeFilterInput!]
+  or: [InstitutionRepresentativeFilterInput!]
+  institution: InstitutionFilterInput
+  user: UserFilterInput
+  role: InstitutionRepresentativeRoleOperationFilterInput
+  pending: BooleanOperationFilterInput
+}
+
+input InstitutionRepresentativeRoleOperationFilterInput {
+  eq: InstitutionRepresentativeRole
+  neq: InstitutionRepresentativeRole
+  in: [InstitutionRepresentativeRole!]
+  nin: [InstitutionRepresentativeRole!]
 }
 
 input InstitutionSortInput {
@@ -2028,6 +2095,13 @@ input IntOperationFilterInput {
   nlte: Int
 }
 
+input ListComponentAssemblyFilterTypeFilterInput {
+  all: ComponentAssemblyFilterInput
+  none: ComponentAssemblyFilterInput
+  some: ComponentAssemblyFilterInput
+  any: Boolean
+}
+
 input ListComponentCategoryOperationFilterInput {
   all: ComponentCategoryOperationFilterInput
   none: ComponentCategoryOperationFilterInput
@@ -2039,6 +2113,13 @@ input ListComponentFilterTypeFilterInput {
   all: ComponentFilterInput
   none: ComponentFilterInput
   some: ComponentFilterInput
+  any: Boolean
+}
+
+input ListComponentManufacturerFilterTypeFilterInput {
+  all: ComponentManufacturerFilterInput
+  none: ComponentManufacturerFilterInput
+  some: ComponentManufacturerFilterInput
   any: Boolean
 }
 
@@ -2060,6 +2141,20 @@ input ListInstitutionFilterTypeFilterInput {
   all: InstitutionFilterInput
   none: InstitutionFilterInput
   some: InstitutionFilterInput
+  any: Boolean
+}
+
+input ListInstitutionMethodDeveloperFilterTypeFilterInput {
+  all: InstitutionMethodDeveloperFilterInput
+  none: InstitutionMethodDeveloperFilterInput
+  some: InstitutionMethodDeveloperFilterInput
+  any: Boolean
+}
+
+input ListInstitutionRepresentativeFilterTypeFilterInput {
+  all: InstitutionRepresentativeFilterInput
+  none: InstitutionRepresentativeFilterInput
+  some: InstitutionRepresentativeFilterInput
   any: Boolean
 }
 
@@ -2098,6 +2193,13 @@ input ListUserFilterTypeFilterInput {
   any: Boolean
 }
 
+input ListUserMethodDeveloperFilterTypeFilterInput {
+  all: UserMethodDeveloperFilterInput
+  none: UserMethodDeveloperFilterInput
+  some: UserMethodDeveloperFilterInput
+  any: Boolean
+}
+
 input LoginUserInput {
   email: String!
   password: String!
@@ -2130,7 +2232,9 @@ input MethodFilterInput {
   calculationLocator: UrlOperationFilterInput
   categories: ListMethodCategoryOperationFilterInput
   institutionDevelopers: ListInstitutionFilterTypeFilterInput
+  institutionDeveloperEdges: ListInstitutionMethodDeveloperFilterTypeFilterInput
   userDevelopers: ListUserFilterTypeFilterInput
+  userDeveloperEdges: ListUserMethodDeveloperFilterTypeFilterInput
   manager: InstitutionFilterInput
 }
 
@@ -2147,6 +2251,13 @@ input MethodSortInput {
   manager: InstitutionSortInput
   id: SortEnumType
   version: SortEnumType
+}
+
+input NullableOfPrimeSurfaceOperationFilterInput {
+  eq: PrimeSurface
+  neq: PrimeSurface
+  in: [PrimeSurface]
+  nin: [PrimeSurface]
 }
 
 input NumerationFilterInput {
@@ -2472,7 +2583,17 @@ input UserFilterInput {
   or: [UserFilterInput!]
   id: UuidOperationFilterInput
   developedMethods: ListMethodFilterTypeFilterInput
+  developedMethodEdges: ListUserMethodDeveloperFilterTypeFilterInput
   representedInstitutions: ListInstitutionFilterTypeFilterInput
+  representedInstitutionEdges: ListInstitutionRepresentativeFilterTypeFilterInput
+}
+
+input UserMethodDeveloperFilterInput {
+  and: [UserMethodDeveloperFilterInput!]
+  or: [UserMethodDeveloperFilterInput!]
+  method: MethodFilterInput
+  user: UserFilterInput
+  pending: BooleanOperationFilterInput
 }
 
 input UserSortInput {

--- a/backend/test/Integration/GraphQl/__snapshots__/GraphQlSchemaTests.IsUnchanged.snap
+++ b/backend/test/Integration/GraphQl/__snapshots__/GraphQlSchemaTests.IsUnchanged.snap
@@ -1716,6 +1716,12 @@ input ComponentFilterInput {
   abbreviation: StringOperationFilterInput
   description: StringOperationFilterInput
   categories: ListComponentCategoryOperationFilterInput
+  partOf: ListComponentFilterTypeFilterInput
+  parts: ListComponentFilterTypeFilterInput
+  concretizations: ListComponentFilterTypeFilterInput
+  generalizations: ListComponentFilterTypeFilterInput
+  variants: ListComponentFilterTypeFilterInput
+  manufacturers: ListInstitutionFilterTypeFilterInput
 }
 
 input ComponentSortInput {
@@ -1841,8 +1847,11 @@ input DataFormatFilterInput {
   or: [DataFormatFilterInput!]
   id: UuidOperationFilterInput
   name: StringOperationFilterInput
+  extension: StringOperationFilterInput
   description: StringOperationFilterInput
   mediaType: StringOperationFilterInput
+  schemaLocator: UrlOperationFilterInput
+  manager: InstitutionFilterInput
 }
 
 input DataFormatSortInput {
@@ -1884,6 +1893,7 @@ input DatabaseFilterInput {
   name: StringOperationFilterInput
   description: StringOperationFilterInput
   locator: UrlOperationFilterInput
+  operator: InstitutionFilterInput
 }
 
 input DatabaseSortInput {
@@ -1971,6 +1981,14 @@ input InstitutionFilterInput {
   description: StringOperationFilterInput
   websiteLocator: UrlOperationFilterInput
   state: InstitutionStateOperationFilterInput
+  developedMethods: ListMethodFilterTypeFilterInput
+  managedMethods: ListMethodFilterTypeFilterInput
+  managedDataFormats: ListDataFormatFilterTypeFilterInput
+  manufacturedComponents: ListComponentFilterTypeFilterInput
+  operatedDatabases: ListDatabaseFilterTypeFilterInput
+  manager: InstitutionFilterInput
+  managedInstitutions: ListInstitutionFilterTypeFilterInput
+  representatives: ListUserFilterTypeFilterInput
 }
 
 input InstitutionSortInput {
@@ -2000,10 +2018,52 @@ input ListComponentCategoryOperationFilterInput {
   any: Boolean
 }
 
+input ListComponentFilterTypeFilterInput {
+  all: ComponentFilterInput
+  none: ComponentFilterInput
+  some: ComponentFilterInput
+  any: Boolean
+}
+
+input ListDataFormatFilterTypeFilterInput {
+  all: DataFormatFilterInput
+  none: DataFormatFilterInput
+  some: DataFormatFilterInput
+  any: Boolean
+}
+
+input ListDatabaseFilterTypeFilterInput {
+  all: DatabaseFilterInput
+  none: DatabaseFilterInput
+  some: DatabaseFilterInput
+  any: Boolean
+}
+
+input ListInstitutionFilterTypeFilterInput {
+  all: InstitutionFilterInput
+  none: InstitutionFilterInput
+  some: InstitutionFilterInput
+  any: Boolean
+}
+
 input ListMethodCategoryOperationFilterInput {
   all: MethodCategoryOperationFilterInput
   none: MethodCategoryOperationFilterInput
   some: MethodCategoryOperationFilterInput
+  any: Boolean
+}
+
+input ListMethodFilterTypeFilterInput {
+  all: MethodFilterInput
+  none: MethodFilterInput
+  some: MethodFilterInput
+  any: Boolean
+}
+
+input ListUserFilterTypeFilterInput {
+  all: UserFilterInput
+  none: UserFilterInput
+  some: UserFilterInput
   any: Boolean
 }
 
@@ -2034,7 +2094,11 @@ input MethodFilterInput {
   id: UuidOperationFilterInput
   name: StringOperationFilterInput
   description: StringOperationFilterInput
+  calculationLocator: UrlOperationFilterInput
   categories: ListMethodCategoryOperationFilterInput
+  institutionDevelopers: ListInstitutionFilterTypeFilterInput
+  userDevelopers: ListUserFilterTypeFilterInput
+  manager: InstitutionFilterInput
 }
 
 input MethodSortInput {
@@ -2320,6 +2384,14 @@ input UrlOperationFilterInput {
   nlt: Url
   lte: Url
   nlte: Url
+}
+
+input UserFilterInput {
+  and: [UserFilterInput!]
+  or: [UserFilterInput!]
+  id: UuidOperationFilterInput
+  developedMethods: ListMethodFilterTypeFilterInput
+  representedInstitutions: ListInstitutionFilterTypeFilterInput
 }
 
 input UserSortInput {

--- a/frontend/type-defs.graphqls
+++ b/frontend/type-defs.graphqls
@@ -1851,6 +1851,8 @@ input DataFormatFilterInput {
   description: StringOperationFilterInput
   mediaType: StringOperationFilterInput
   schemaLocator: UrlOperationFilterInput
+  standard: StandardFilterInput
+  publication: PublicationFilterInput
   manager: InstitutionFilterInput
 }
 
@@ -2011,6 +2013,21 @@ input InstitutionStateOperationFilterInput {
   nin: [InstitutionState!]
 }
 
+input IntOperationFilterInput {
+  eq: Int
+  neq: Int
+  in: [Int]
+  nin: [Int]
+  gt: Int
+  ngt: Int
+  gte: Int
+  ngte: Int
+  lt: Int
+  nlt: Int
+  lte: Int
+  nlte: Int
+}
+
 input ListComponentCategoryOperationFilterInput {
   all: ComponentCategoryOperationFilterInput
   none: ComponentCategoryOperationFilterInput
@@ -2060,6 +2077,20 @@ input ListMethodFilterTypeFilterInput {
   any: Boolean
 }
 
+input ListStandardizerOperationFilterInput {
+  all: StandardizerOperationFilterInput
+  none: StandardizerOperationFilterInput
+  some: StandardizerOperationFilterInput
+  any: Boolean
+}
+
+input ListStringOperationFilterInput {
+  all: StringOperationFilterInput
+  none: StringOperationFilterInput
+  some: StringOperationFilterInput
+  any: Boolean
+}
+
 input ListUserFilterTypeFilterInput {
   all: UserFilterInput
   none: UserFilterInput
@@ -2094,6 +2125,8 @@ input MethodFilterInput {
   id: UuidOperationFilterInput
   name: StringOperationFilterInput
   description: StringOperationFilterInput
+  standard: StandardFilterInput
+  publication: PublicationFilterInput
   calculationLocator: UrlOperationFilterInput
   categories: ListMethodCategoryOperationFilterInput
   institutionDevelopers: ListInstitutionFilterTypeFilterInput
@@ -2114,6 +2147,14 @@ input MethodSortInput {
   manager: InstitutionSortInput
   id: SortEnumType
   version: SortEnumType
+}
+
+input NumerationFilterInput {
+  and: [NumerationFilterInput!]
+  or: [NumerationFilterInput!]
+  prefix: StringOperationFilterInput
+  mainNumber: StringOperationFilterInput
+  suffix: StringOperationFilterInput
 }
 
 input NumerationSortInput {
@@ -2148,6 +2189,24 @@ input PhotovoltaicDataPropositionInput {
   not: PhotovoltaicDataPropositionInput
   or: [PhotovoltaicDataPropositionInput!]
   resources: GetHttpsResourcesPropositionInput
+}
+
+input PublicationFilterInput {
+  and: [PublicationFilterInput!]
+  or: [PublicationFilterInput!]
+  title: StringOperationFilterInput
+  abstract: StringOperationFilterInput
+  "Referenced section"
+  section: StringOperationFilterInput
+  authors: ListStringOperationFilterInput
+  "The Digital Object Identifier (DOI) is a very important persistent identifier for publications. It MUST be defined here if it is available for a publication."
+  doi: StringOperationFilterInput
+  "The website arXiv.org is a free and open-access archive for publications. The arXiv identifier can be used to define a publication."
+  arXiv: StringOperationFilterInput
+  "A Uniform Resource Name (URN) can be used to define a publication. TODO: Improve the regex pattern to further restrict the string."
+  urn: StringOperationFilterInput
+  "If a persistent identifiert like DOI is defined above, this webAdress can define a convenient web address to access the publication. However, if no persistent identifier exist, this web address is the only identifier of this publication. In this case, it is important to choose a web address with a high probability to persist long."
+  webAddress: UrlOperationFilterInput
 }
 
 input PublicationSortInput {
@@ -2239,6 +2298,21 @@ input SetUserPhoneNumberInput {
 }
 
 "`ISO 52022` is an example of the abbreviation of a standardizer and the main number of the identifier."
+input StandardFilterInput {
+  and: [StandardFilterInput!]
+  or: [StandardFilterInput!]
+  title: StringOperationFilterInput
+  abstract: StringOperationFilterInput
+  "The section of the standard to which the reference refers to."
+  section: StringOperationFilterInput
+  "It is important to define the year in which the standard was issued because there can be relevant updates of one standard."
+  year: IntOperationFilterInput
+  numeration: NumerationFilterInput
+  standardizers: ListStandardizerOperationFilterInput
+  locator: UrlOperationFilterInput
+}
+
+"`ISO 52022` is an example of the abbreviation of a standardizer and the main number of the identifier."
 input StandardSortInput {
   title: SortEnumType
   abstract: SortEnumType
@@ -2248,6 +2322,13 @@ input StandardSortInput {
   year: SortEnumType
   numeration: NumerationSortInput
   locator: UriSortInput
+}
+
+input StandardizerOperationFilterInput {
+  eq: Standardizer
+  neq: Standardizer
+  in: [Standardizer!]
+  nin: [Standardizer!]
 }
 
 input StringOperationFilterInput {

--- a/frontend/type-defs.graphqls
+++ b/frontend/type-defs.graphqls
@@ -1658,6 +1658,26 @@ input AddUserRoleInput {
   userId: Uuid!
 }
 
+input BooleanOperationFilterInput {
+  eq: Boolean
+  neq: Boolean
+}
+
+input ByteOperationFilterInput {
+  eq: Byte
+  neq: Byte
+  in: [Byte]
+  nin: [Byte]
+  gt: Byte
+  ngt: Byte
+  gte: Byte
+  ngte: Byte
+  lt: Byte
+  nlt: Byte
+  lte: Byte
+  nlte: Byte
+}
+
 input CalorimetricDataPropositionInput {
   and: [CalorimetricDataPropositionInput!]
   componentId: UuidPropositionInput
@@ -1701,6 +1721,15 @@ input ClosedIntervalInput {
   upperBound: Float!
 }
 
+input ComponentAssemblyFilterInput {
+  and: [ComponentAssemblyFilterInput!]
+  or: [ComponentAssemblyFilterInput!]
+  assembledComponent: ComponentFilterInput
+  partComponent: ComponentFilterInput
+  index: ByteOperationFilterInput
+  primeSurface: NullableOfPrimeSurfaceOperationFilterInput
+}
+
 input ComponentCategoryOperationFilterInput {
   eq: ComponentCategory
   neq: ComponentCategory
@@ -1718,10 +1747,21 @@ input ComponentFilterInput {
   categories: ListComponentCategoryOperationFilterInput
   partOf: ListComponentFilterTypeFilterInput
   parts: ListComponentFilterTypeFilterInput
+  partOfEdges: ListComponentAssemblyFilterTypeFilterInput
+  partEdges: ListComponentAssemblyFilterTypeFilterInput
   concretizations: ListComponentFilterTypeFilterInput
   generalizations: ListComponentFilterTypeFilterInput
   variants: ListComponentFilterTypeFilterInput
   manufacturers: ListInstitutionFilterTypeFilterInput
+  manufacturerEdges: ListComponentManufacturerFilterTypeFilterInput
+}
+
+input ComponentManufacturerFilterInput {
+  and: [ComponentManufacturerFilterInput!]
+  or: [ComponentManufacturerFilterInput!]
+  component: ComponentFilterInput
+  institution: InstitutionFilterInput
+  pending: BooleanOperationFilterInput
 }
 
 input ComponentSortInput {
@@ -1984,13 +2024,40 @@ input InstitutionFilterInput {
   websiteLocator: UrlOperationFilterInput
   state: InstitutionStateOperationFilterInput
   developedMethods: ListMethodFilterTypeFilterInput
+  developedMethodEdges: ListInstitutionMethodDeveloperFilterTypeFilterInput
   managedMethods: ListMethodFilterTypeFilterInput
   managedDataFormats: ListDataFormatFilterTypeFilterInput
   manufacturedComponents: ListComponentFilterTypeFilterInput
+  manufacturedComponentEdges: ListComponentManufacturerFilterTypeFilterInput
   operatedDatabases: ListDatabaseFilterTypeFilterInput
   manager: InstitutionFilterInput
   managedInstitutions: ListInstitutionFilterTypeFilterInput
   representatives: ListUserFilterTypeFilterInput
+  representativeEdges: ListInstitutionRepresentativeFilterTypeFilterInput
+}
+
+input InstitutionMethodDeveloperFilterInput {
+  and: [InstitutionMethodDeveloperFilterInput!]
+  or: [InstitutionMethodDeveloperFilterInput!]
+  method: MethodFilterInput
+  institution: InstitutionFilterInput
+  pending: BooleanOperationFilterInput
+}
+
+input InstitutionRepresentativeFilterInput {
+  and: [InstitutionRepresentativeFilterInput!]
+  or: [InstitutionRepresentativeFilterInput!]
+  institution: InstitutionFilterInput
+  user: UserFilterInput
+  role: InstitutionRepresentativeRoleOperationFilterInput
+  pending: BooleanOperationFilterInput
+}
+
+input InstitutionRepresentativeRoleOperationFilterInput {
+  eq: InstitutionRepresentativeRole
+  neq: InstitutionRepresentativeRole
+  in: [InstitutionRepresentativeRole!]
+  nin: [InstitutionRepresentativeRole!]
 }
 
 input InstitutionSortInput {
@@ -2028,6 +2095,13 @@ input IntOperationFilterInput {
   nlte: Int
 }
 
+input ListComponentAssemblyFilterTypeFilterInput {
+  all: ComponentAssemblyFilterInput
+  none: ComponentAssemblyFilterInput
+  some: ComponentAssemblyFilterInput
+  any: Boolean
+}
+
 input ListComponentCategoryOperationFilterInput {
   all: ComponentCategoryOperationFilterInput
   none: ComponentCategoryOperationFilterInput
@@ -2039,6 +2113,13 @@ input ListComponentFilterTypeFilterInput {
   all: ComponentFilterInput
   none: ComponentFilterInput
   some: ComponentFilterInput
+  any: Boolean
+}
+
+input ListComponentManufacturerFilterTypeFilterInput {
+  all: ComponentManufacturerFilterInput
+  none: ComponentManufacturerFilterInput
+  some: ComponentManufacturerFilterInput
   any: Boolean
 }
 
@@ -2060,6 +2141,20 @@ input ListInstitutionFilterTypeFilterInput {
   all: InstitutionFilterInput
   none: InstitutionFilterInput
   some: InstitutionFilterInput
+  any: Boolean
+}
+
+input ListInstitutionMethodDeveloperFilterTypeFilterInput {
+  all: InstitutionMethodDeveloperFilterInput
+  none: InstitutionMethodDeveloperFilterInput
+  some: InstitutionMethodDeveloperFilterInput
+  any: Boolean
+}
+
+input ListInstitutionRepresentativeFilterTypeFilterInput {
+  all: InstitutionRepresentativeFilterInput
+  none: InstitutionRepresentativeFilterInput
+  some: InstitutionRepresentativeFilterInput
   any: Boolean
 }
 
@@ -2098,6 +2193,13 @@ input ListUserFilterTypeFilterInput {
   any: Boolean
 }
 
+input ListUserMethodDeveloperFilterTypeFilterInput {
+  all: UserMethodDeveloperFilterInput
+  none: UserMethodDeveloperFilterInput
+  some: UserMethodDeveloperFilterInput
+  any: Boolean
+}
+
 input LoginUserInput {
   email: String!
   password: String!
@@ -2130,7 +2232,9 @@ input MethodFilterInput {
   calculationLocator: UrlOperationFilterInput
   categories: ListMethodCategoryOperationFilterInput
   institutionDevelopers: ListInstitutionFilterTypeFilterInput
+  institutionDeveloperEdges: ListInstitutionMethodDeveloperFilterTypeFilterInput
   userDevelopers: ListUserFilterTypeFilterInput
+  userDeveloperEdges: ListUserMethodDeveloperFilterTypeFilterInput
   manager: InstitutionFilterInput
 }
 
@@ -2147,6 +2251,13 @@ input MethodSortInput {
   manager: InstitutionSortInput
   id: SortEnumType
   version: SortEnumType
+}
+
+input NullableOfPrimeSurfaceOperationFilterInput {
+  eq: PrimeSurface
+  neq: PrimeSurface
+  in: [PrimeSurface]
+  nin: [PrimeSurface]
 }
 
 input NumerationFilterInput {
@@ -2472,7 +2583,17 @@ input UserFilterInput {
   or: [UserFilterInput!]
   id: UuidOperationFilterInput
   developedMethods: ListMethodFilterTypeFilterInput
+  developedMethodEdges: ListUserMethodDeveloperFilterTypeFilterInput
   representedInstitutions: ListInstitutionFilterTypeFilterInput
+  representedInstitutionEdges: ListInstitutionRepresentativeFilterTypeFilterInput
+}
+
+input UserMethodDeveloperFilterInput {
+  and: [UserMethodDeveloperFilterInput!]
+  or: [UserMethodDeveloperFilterInput!]
+  method: MethodFilterInput
+  user: UserFilterInput
+  pending: BooleanOperationFilterInput
 }
 
 input UserSortInput {

--- a/frontend/type-defs.graphqls
+++ b/frontend/type-defs.graphqls
@@ -1716,6 +1716,12 @@ input ComponentFilterInput {
   abbreviation: StringOperationFilterInput
   description: StringOperationFilterInput
   categories: ListComponentCategoryOperationFilterInput
+  partOf: ListComponentFilterTypeFilterInput
+  parts: ListComponentFilterTypeFilterInput
+  concretizations: ListComponentFilterTypeFilterInput
+  generalizations: ListComponentFilterTypeFilterInput
+  variants: ListComponentFilterTypeFilterInput
+  manufacturers: ListInstitutionFilterTypeFilterInput
 }
 
 input ComponentSortInput {
@@ -1841,8 +1847,11 @@ input DataFormatFilterInput {
   or: [DataFormatFilterInput!]
   id: UuidOperationFilterInput
   name: StringOperationFilterInput
+  extension: StringOperationFilterInput
   description: StringOperationFilterInput
   mediaType: StringOperationFilterInput
+  schemaLocator: UrlOperationFilterInput
+  manager: InstitutionFilterInput
 }
 
 input DataFormatSortInput {
@@ -1884,6 +1893,7 @@ input DatabaseFilterInput {
   name: StringOperationFilterInput
   description: StringOperationFilterInput
   locator: UrlOperationFilterInput
+  operator: InstitutionFilterInput
 }
 
 input DatabaseSortInput {
@@ -1971,6 +1981,14 @@ input InstitutionFilterInput {
   description: StringOperationFilterInput
   websiteLocator: UrlOperationFilterInput
   state: InstitutionStateOperationFilterInput
+  developedMethods: ListMethodFilterTypeFilterInput
+  managedMethods: ListMethodFilterTypeFilterInput
+  managedDataFormats: ListDataFormatFilterTypeFilterInput
+  manufacturedComponents: ListComponentFilterTypeFilterInput
+  operatedDatabases: ListDatabaseFilterTypeFilterInput
+  manager: InstitutionFilterInput
+  managedInstitutions: ListInstitutionFilterTypeFilterInput
+  representatives: ListUserFilterTypeFilterInput
 }
 
 input InstitutionSortInput {
@@ -2000,10 +2018,52 @@ input ListComponentCategoryOperationFilterInput {
   any: Boolean
 }
 
+input ListComponentFilterTypeFilterInput {
+  all: ComponentFilterInput
+  none: ComponentFilterInput
+  some: ComponentFilterInput
+  any: Boolean
+}
+
+input ListDataFormatFilterTypeFilterInput {
+  all: DataFormatFilterInput
+  none: DataFormatFilterInput
+  some: DataFormatFilterInput
+  any: Boolean
+}
+
+input ListDatabaseFilterTypeFilterInput {
+  all: DatabaseFilterInput
+  none: DatabaseFilterInput
+  some: DatabaseFilterInput
+  any: Boolean
+}
+
+input ListInstitutionFilterTypeFilterInput {
+  all: InstitutionFilterInput
+  none: InstitutionFilterInput
+  some: InstitutionFilterInput
+  any: Boolean
+}
+
 input ListMethodCategoryOperationFilterInput {
   all: MethodCategoryOperationFilterInput
   none: MethodCategoryOperationFilterInput
   some: MethodCategoryOperationFilterInput
+  any: Boolean
+}
+
+input ListMethodFilterTypeFilterInput {
+  all: MethodFilterInput
+  none: MethodFilterInput
+  some: MethodFilterInput
+  any: Boolean
+}
+
+input ListUserFilterTypeFilterInput {
+  all: UserFilterInput
+  none: UserFilterInput
+  some: UserFilterInput
   any: Boolean
 }
 
@@ -2034,7 +2094,11 @@ input MethodFilterInput {
   id: UuidOperationFilterInput
   name: StringOperationFilterInput
   description: StringOperationFilterInput
+  calculationLocator: UrlOperationFilterInput
   categories: ListMethodCategoryOperationFilterInput
+  institutionDevelopers: ListInstitutionFilterTypeFilterInput
+  userDevelopers: ListUserFilterTypeFilterInput
+  manager: InstitutionFilterInput
 }
 
 input MethodSortInput {
@@ -2320,6 +2384,14 @@ input UrlOperationFilterInput {
   nlt: Url
   lte: Url
   nlte: Url
+}
+
+input UserFilterInput {
+  and: [UserFilterInput!]
+  or: [UserFilterInput!]
+  id: UuidOperationFilterInput
+  developedMethods: ListMethodFilterTypeFilterInput
+  representedInstitutions: ListInstitutionFilterTypeFilterInput
 }
 
 input UserSortInput {


### PR DESCRIPTION
This makes for example the following queries possible:

```graphql
query {
  components(
    where: {
      and: [
        { name: {contains: "A"} },
        { manufacturerEdges: { some: { and: [
          { pending: { eq: false } },
          { institution: { name: {contains: "I"} } }
        ]}}}
      ]
    }) {
    nodes {
      uuid
      name
    }
  }
} 
```

and

```graphql
query {
  components(
    where: {
      and: [
        { name: { contains: "A" } },
        { manufacturers: { some: { name: { contains: "I" }}}}
      ]
    }) {
    nodes {
      uuid
      name
    }
  }
} 
```

Note that the second query also includes components with pending manufacturers containing `I` in their names.