### PR TITLE
Force `docker compose run` to pass `GROUP_ID` and `USER_ID`

### DIFF
--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -81,6 +81,9 @@ services:
     build:
       context: "./backend"
       dockerfile: "./Dockerfile.development"
+      args:
+        GROUP_ID: "${GROUP_ID:?required}"
+        USER_ID: "${USER_ID:?required}"
     depends_on:
       database:
         condition: "service_started"

--- a/docker.mk
+++ b/docker.mk
@@ -7,6 +7,11 @@ SHELL := /usr/bin/env bash
 .SHELLFLAGS := -o errexit -o errtrace -o nounset -o pipefail -c
 MAKEFLAGS += --warn-undefined-variables
 
+GROUP_ID ?= $(shell id --group)
+USER_ID ?= $(shell id --user)
+export GROUP_ID
+export USER_ID
+
 COMPOSE_BAKE=true
 SERVICE=
 
@@ -62,8 +67,8 @@ pull : ## Pull images
 build : symlink dotenv pull ## Build images
 	docker compose build \
 		--pull \
-		--build-arg GROUP_ID=$(shell id --group) \
-		--build-arg USER_ID=$(shell id --user) ${SERVICE}
+		--build-arg GROUP_ID=$(GROUP_ID) \
+		--build-arg USER_ID=$(USER_ID) ${SERVICE}
 .PHONY : build
 
 bake : ## Print docker-compose file equivalent bake file


### PR DESCRIPTION
`make shell SERVICE=backend` has failed in develop #256 . The fix forces docker compose to pass the required arguments. Resolves #256.

@simonwacker Do you agree to the changes?

If the merge request passes the review, https://github.com/building-envelope-data/database/pull/99 can be changed accordingly.